### PR TITLE
Chore: add catalog info [SC-243205]

### DIFF
--- a/.infra/catalog-info.yaml
+++ b/.infra/catalog-info.yaml
@@ -1,0 +1,19 @@
+apiVersion: backstage.io/v1alpha1
+kind: Component
+metadata:
+  annotations:
+    github.com/project-slug: ThirtyMadison/resque-alive
+  description: Resque Alive
+  labels:
+    has_frontend: 'False'
+  links:
+  - icon: github
+    title: Github
+    url: https://github.com/ThirtyMadison/resque-alive
+  name: resque-alive
+  tags:
+  - ruby
+spec:
+  dependsOn: []
+  lifecycle: production
+  type: service


### PR DESCRIPTION
Add catalog info https://app.shortcut.com/thirty-madison/story/243205/set-codeowners-catalog-info-for-every-repo